### PR TITLE
大佬，发现您的项目引入了org.apache.solr:solr-solrj@8.2.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.common</groupId>
 	<artifactId>CommonMethod</artifactId>
@@ -140,7 +139,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
-			<version>8.2.0</version>
+			<version>8.6.3</version>
 		</dependency>
 
 		<!-- kafka -->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Solr 安全漏洞
缺陷组件：org.apache.solr:solr-solrj@8.2.0
漏洞编号：CVE-2020-13957
漏洞描述：Apache Solr是美国阿帕奇（Apache）软件基金会的一款基于Lucene（一款全文搜索引擎）的搜索服务器。该产品支持层面搜索、垂直搜索、高亮显示搜索结果等。
Apache Solr 存在安全漏洞，该漏洞源于缺少必要的身份验证，攻击者可利用该漏洞远程代码执行。以下产品及版本受到影响：6.6.0版本到6.6.6版本、7.0.0版本到7.7.3版本，8.0.0版本到8.6.2版本。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-57571
影响范围：[6.6.0, 8.6.3)
最小修复版本：8.6.3
缺陷组件引入路径：com.common:CommonMethod@2.0.0->org.apache.solr:solr-solrj@8.2.0
```
另外我运行这个项目时，IDE的安全插件提示还有97个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pddc06